### PR TITLE
cuminc p-values

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ggsurvfit
 Title: Easy and Flexible Time-to-Event Figures
-Version: 0.1.0.9006
+Version: 0.1.0.9007
 Authors@R: c(
     person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0003-0862-2018")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ggsurvfit (development version)
 
+* Adding ability to report comparative p-values from cumulative incidence plots created with `tidycmprsk::cuminc()` (#84)
+
 * Adding support for multi-state models created with `survfit()`, i.e. competing risks from the survival package. (#83)
 
 * Changed the default of the `ggsurvfit_build(combine_plots=)` argument to `TRUE`.

--- a/man/add_pvalue.Rd
+++ b/man/add_pvalue.Rd
@@ -38,8 +38,11 @@ a ggplot2 figure
 \item \code{add_pvalue("annotation")}: Add a p-value text annotation via \code{ggplot2::annotation("text")}
 }
 
-P-values are calculated with \code{survival::survdiff()}.
+P-values are calculated with \code{survival::survdiff()} or \code{tidycmprsk::glance()}.
 Examples of custom placement located in the help file for \code{survfit_p()}.
+
+When a competing risks figure includes multiple outcomes, only the p-value
+comparing stratum for the \emph{first} outcome can be placed.
 }
 \examples{
 survfit2(Surv(time, status) ~ surg, df_colon) \%>\%

--- a/tests/testthat/_snaps/add_pvalue/cuminc2-pvalue.svg
+++ b/tests/testthat/_snaps/add_pvalue/cuminc2-pvalue.svg
@@ -1,0 +1,481 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpNS40OHw3MTQuNTJ8NS40OHw0MTAuMDg='>
+    <rect x='5.48' y='5.48' width='709.04' height='404.60' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NS40OHw0MTAuMDg=)'>
+<rect x='5.48' y='5.48' width='709.04' height='404.60' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHw3MTQuNTJ8NDEwLjA4fDQ5MC4zMA=='>
+    <rect x='5.48' y='410.08' width='709.04' height='80.22' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NDEwLjA4fDQ5MC4zMA==)'>
+<rect x='5.48' y='410.08' width='709.04' height='80.22' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHw3MTQuNTJ8NDkwLjMwfDU3MC41Mg=='>
+    <rect x='5.48' y='490.30' width='709.04' height='80.22' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NDkwLjMwfDU3MC41Mg==)'>
+<rect x='5.48' y='490.30' width='709.04' height='80.22' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMTAuOTZ8NzA5LjA0fDEwLjk2fDQwNC42MA=='>
+    <rect x='10.96' y='10.96' width='698.08' height='393.64' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMTAuOTZ8NzA5LjA0fDEwLjk2fDQwNC42MA==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NS40OHw0MTAuMDg=)'>
+<rect x='5.48' y='5.48' width='709.04' height='404.60' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpNTMuODN8NzA5LjA0fDI4LjI2fDMyNi42Mw=='>
+    <rect x='53.83' y='28.26' width='655.21' height='298.37' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTMuODN8NzA5LjA0fDI4LjI2fDMyNi42Mw==)'>
+<rect x='53.83' y='28.26' width='655.21' height='298.37' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='53.83,280.43 709.04,280.43 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='53.83,215.14 709.04,215.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='53.83,149.85 709.04,149.85 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='53.83,84.57 709.04,84.57 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='145.66,326.63 145.66,28.26 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='269.75,326.63 269.75,28.26 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='393.84,326.63 393.84,28.26 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='517.94,326.63 517.94,28.26 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='642.03,326.63 642.03,28.26 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='53.83,313.07 709.04,313.07 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='53.83,247.78 709.04,247.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='53.83,182.50 709.04,182.50 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='53.83,117.21 709.04,117.21 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='53.83,51.92 709.04,51.92 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='83.61,326.63 83.61,28.26 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='207.70,326.63 207.70,28.26 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='331.80,326.63 331.80,28.26 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='455.89,326.63 455.89,28.26 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='579.98,326.63 579.98,28.26 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='704.08,326.63 704.08,28.26 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='83.61,313.07 171.22,313.07 171.22,313.07 264.04,313.07 264.04,306.41 266.77,306.41 266.77,299.75 291.34,299.75 291.34,299.75 334.78,299.75 334.78,299.75 339.99,299.75 339.99,299.75 344.45,299.75 344.45,299.75 367.54,299.75 367.54,293.08 375.48,293.08 375.48,293.08 383.92,293.08 383.92,293.08 394.59,293.08 394.59,293.08 397.07,293.08 397.07,286.42 423.13,286.42 423.13,279.76 432.56,279.76 432.56,273.10 451.42,273.10 451.42,266.44 469.54,266.44 469.54,266.44 472.02,266.44 472.02,266.44 482.45,266.44 482.45,266.44 484.68,266.44 484.68,266.44 491.38,266.44 491.38,266.44 491.63,266.44 491.63,266.44 492.13,266.44 492.13,259.78 503.54,259.78 503.54,253.11 515.95,253.11 515.95,246.45 516.20,246.45 516.20,246.45 519.43,246.45 519.43,239.79 521.41,239.79 521.41,239.79 525.63,239.79 525.63,233.13 537.54,233.13 537.54,233.13 539.53,233.13 539.53,233.13 541.02,233.13 541.02,233.13 560.63,233.13 560.63,226.47 563.60,226.47 563.60,219.80 568.57,219.80 568.57,213.14 573.78,213.14 573.78,206.48 575.27,206.48 575.27,199.82 583.46,199.82 583.46,193.16 600.09,193.16 600.09,193.16 602.32,193.16 602.32,193.16 609.52,193.16 609.52,193.16 612.99,193.16 612.99,193.16 619.69,193.16 619.69,193.16 625.40,193.16 625.40,186.49 639.80,186.49 639.80,179.83 648.73,179.83 648.73,173.17 650.97,173.17 650.97,166.51 664.62,166.51 664.62,166.51 669.33,166.51 669.33,159.85 674.54,159.85 674.54,153.18 676.53,153.18 676.53,153.18 679.26,153.18 679.26,153.18 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<polyline points='83.61,313.07 215.89,313.07 215.89,306.67 240.46,306.67 240.46,306.67 299.78,306.67 299.78,300.27 312.93,300.27 312.93,293.87 325.10,293.87 325.10,287.47 329.81,287.47 329.81,287.47 331.05,287.47 331.05,287.47 332.29,287.47 332.29,287.47 333.53,287.47 333.53,281.07 335.77,281.07 335.77,274.67 342.22,274.67 342.22,268.27 344.95,268.27 344.95,261.87 345.45,261.87 345.45,261.87 361.08,261.87 361.08,255.46 386.15,255.46 386.15,255.46 386.65,255.46 386.65,255.46 392.11,255.46 392.11,249.06 394.34,249.06 394.34,242.66 398.31,242.66 398.31,236.26 403.52,236.26 403.52,229.86 406.25,229.86 406.25,229.86 408.24,229.86 408.24,223.46 409.98,223.46 409.98,217.06 439.51,217.06 439.51,210.66 442.49,210.66 442.49,204.26 444.47,204.26 444.47,204.26 447.20,204.26 447.20,204.26 458.37,204.26 458.37,204.26 461.10,204.26 461.10,197.86 467.06,197.86 467.06,191.46 470.53,191.46 470.53,185.06 471.77,185.06 471.77,178.66 475.00,178.66 475.00,178.66 486.42,178.66 486.42,178.66 492.37,178.66 492.37,178.66 494.86,178.66 494.86,178.66 497.34,178.66 497.34,178.66 516.70,178.66 516.70,178.66 516.94,178.66 516.94,172.26 524.64,172.26 524.64,172.26 530.35,172.26 530.35,165.86 530.84,165.86 530.84,159.45 536.05,159.45 536.05,159.45 545.98,159.45 545.98,153.05 558.64,153.05 558.64,146.65 563.60,146.65 563.60,146.65 579.49,146.65 579.49,146.65 588.17,146.65 588.17,146.65 588.67,146.65 588.67,146.65 595.37,146.65 595.37,140.25 603.31,140.25 603.31,133.85 616.96,133.85 616.96,133.85 627.39,133.85 627.39,127.45 632.85,127.45 632.85,121.05 639.55,121.05 639.55,114.65 646.50,114.65 646.50,114.65 652.45,114.65 652.45,108.25 660.15,108.25 660.15,108.25 672.31,108.25 672.31,101.85 676.28,101.85 676.28,101.85 679.26,101.85 679.26,101.85 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polygon points='264.04,280.24 266.77,280.24 266.77,270.52 291.34,270.52 291.34,270.52 334.78,270.52 334.78,270.52 339.99,270.52 339.99,270.52 344.45,270.52 344.45,270.52 367.54,270.52 367.54,260.98 375.48,260.98 375.48,260.98 383.92,260.98 383.92,260.98 394.59,260.98 394.59,260.98 397.07,260.98 397.07,251.77 423.13,251.77 423.13,242.85 432.56,242.85 432.56,234.15 451.42,234.15 451.42,225.64 469.54,225.64 469.54,225.64 472.02,225.64 472.02,225.64 482.45,225.64 482.45,225.64 484.68,225.64 484.68,225.64 491.38,225.64 491.38,225.64 491.63,225.64 491.63,225.64 492.13,225.64 492.13,217.28 503.54,217.28 503.54,209.06 515.95,209.06 515.95,200.95 516.20,200.95 516.20,200.95 519.43,200.95 519.43,192.95 521.41,192.95 521.41,192.95 525.63,192.95 525.63,185.04 537.54,185.04 537.54,185.04 539.53,185.04 539.53,185.04 541.02,185.04 541.02,185.04 560.63,185.04 560.63,177.21 563.60,177.21 563.60,169.45 568.57,169.45 568.57,161.77 573.78,161.77 573.78,154.15 575.27,154.15 575.27,146.59 583.46,146.59 583.46,139.08 600.09,139.08 600.09,139.08 602.32,139.08 602.32,139.08 609.52,139.08 609.52,139.08 612.99,139.08 612.99,139.08 619.69,139.08 619.69,139.08 625.40,139.08 625.40,131.63 639.80,131.63 639.80,124.22 648.73,124.22 648.73,116.87 650.97,116.87 650.97,109.55 664.62,109.55 664.62,109.55 669.33,109.55 669.33,102.28 674.54,102.28 674.54,95.05 676.53,95.05 676.53,95.05 679.26,95.05 679.26,95.05 679.26,205.66 679.26,205.66 676.53,205.66 676.53,205.66 674.54,205.66 674.54,211.28 669.33,211.28 669.33,216.85 664.62,216.85 664.62,216.85 650.97,216.85 650.97,222.37 648.73,222.37 648.73,227.85 639.80,227.85 639.80,233.27 625.40,233.27 625.40,238.64 619.69,238.64 619.69,238.64 612.99,238.64 612.99,238.64 609.52,238.64 609.52,238.64 602.32,238.64 602.32,238.64 600.09,238.64 600.09,238.64 583.46,238.64 583.46,243.96 575.27,243.96 575.27,249.21 573.78,249.21 573.78,254.40 568.57,254.40 568.57,259.52 563.60,259.52 563.60,264.55 560.63,264.55 560.63,269.51 541.02,269.51 541.02,269.51 539.53,269.51 539.53,269.51 537.54,269.51 537.54,269.51 525.63,269.51 525.63,274.37 521.41,274.37 521.41,274.37 519.43,274.37 519.43,279.13 516.20,279.13 516.20,279.13 515.95,279.13 515.95,283.77 503.54,283.77 503.54,288.28 492.13,288.28 492.13,292.63 491.63,292.63 491.63,292.63 491.38,292.63 491.38,292.63 484.68,292.63 484.68,292.63 482.45,292.63 482.45,292.63 472.02,292.63 472.02,292.63 469.54,292.63 469.54,292.63 451.42,292.63 451.42,296.81 432.56,296.81 432.56,300.76 423.13,300.76 423.13,304.43 397.07,304.43 397.07,307.74 394.59,307.74 394.59,307.74 383.92,307.74 383.92,307.74 375.48,307.74 375.48,307.74 367.54,307.74 367.54,310.52 344.45,310.52 344.45,310.52 339.99,310.52 339.99,310.52 334.78,310.52 334.78,310.52 291.34,310.52 291.34,310.52 266.77,310.52 266.77,312.49 264.04,312.49 ' style='stroke-width: 0.00; stroke: none; fill: #F8766D; fill-opacity: 0.20;' />
+<polyline points='264.04,280.24 266.77,280.24 266.77,270.52 291.34,270.52 291.34,270.52 334.78,270.52 334.78,270.52 339.99,270.52 339.99,270.52 344.45,270.52 344.45,270.52 367.54,270.52 367.54,260.98 375.48,260.98 375.48,260.98 383.92,260.98 383.92,260.98 394.59,260.98 394.59,260.98 397.07,260.98 397.07,251.77 423.13,251.77 423.13,242.85 432.56,242.85 432.56,234.15 451.42,234.15 451.42,225.64 469.54,225.64 469.54,225.64 472.02,225.64 472.02,225.64 482.45,225.64 482.45,225.64 484.68,225.64 484.68,225.64 491.38,225.64 491.38,225.64 491.63,225.64 491.63,225.64 492.13,225.64 492.13,217.28 503.54,217.28 503.54,209.06 515.95,209.06 515.95,200.95 516.20,200.95 516.20,200.95 519.43,200.95 519.43,192.95 521.41,192.95 521.41,192.95 525.63,192.95 525.63,185.04 537.54,185.04 537.54,185.04 539.53,185.04 539.53,185.04 541.02,185.04 541.02,185.04 560.63,185.04 560.63,177.21 563.60,177.21 563.60,169.45 568.57,169.45 568.57,161.77 573.78,161.77 573.78,154.15 575.27,154.15 575.27,146.59 583.46,146.59 583.46,139.08 600.09,139.08 600.09,139.08 602.32,139.08 602.32,139.08 609.52,139.08 609.52,139.08 612.99,139.08 612.99,139.08 619.69,139.08 619.69,139.08 625.40,139.08 625.40,131.63 639.80,131.63 639.80,124.22 648.73,124.22 648.73,116.87 650.97,116.87 650.97,109.55 664.62,109.55 664.62,109.55 669.33,109.55 669.33,102.28 674.54,102.28 674.54,95.05 676.53,95.05 676.53,95.05 679.26,95.05 679.26,95.05 ' style='stroke-width: 1.07; stroke: none;' />
+<polyline points='679.26,205.66 679.26,205.66 676.53,205.66 676.53,205.66 674.54,205.66 674.54,211.28 669.33,211.28 669.33,216.85 664.62,216.85 664.62,216.85 650.97,216.85 650.97,222.37 648.73,222.37 648.73,227.85 639.80,227.85 639.80,233.27 625.40,233.27 625.40,238.64 619.69,238.64 619.69,238.64 612.99,238.64 612.99,238.64 609.52,238.64 609.52,238.64 602.32,238.64 602.32,238.64 600.09,238.64 600.09,238.64 583.46,238.64 583.46,243.96 575.27,243.96 575.27,249.21 573.78,249.21 573.78,254.40 568.57,254.40 568.57,259.52 563.60,259.52 563.60,264.55 560.63,264.55 560.63,269.51 541.02,269.51 541.02,269.51 539.53,269.51 539.53,269.51 537.54,269.51 537.54,269.51 525.63,269.51 525.63,274.37 521.41,274.37 521.41,274.37 519.43,274.37 519.43,279.13 516.20,279.13 516.20,279.13 515.95,279.13 515.95,283.77 503.54,283.77 503.54,288.28 492.13,288.28 492.13,292.63 491.63,292.63 491.63,292.63 491.38,292.63 491.38,292.63 484.68,292.63 484.68,292.63 482.45,292.63 482.45,292.63 472.02,292.63 472.02,292.63 469.54,292.63 469.54,292.63 451.42,292.63 451.42,296.81 432.56,296.81 432.56,300.76 423.13,300.76 423.13,304.43 397.07,304.43 397.07,307.74 394.59,307.74 394.59,307.74 383.92,307.74 383.92,307.74 375.48,307.74 375.48,307.74 367.54,307.74 367.54,310.52 344.45,310.52 344.45,310.52 339.99,310.52 339.99,310.52 334.78,310.52 334.78,310.52 291.34,310.52 291.34,310.52 266.77,310.52 266.77,312.49 264.04,312.49 ' style='stroke-width: 1.07; stroke: none;' />
+<polygon points='215.89,281.44 240.46,281.44 240.46,281.44 299.78,281.44 299.78,272.10 312.93,272.10 312.93,262.93 325.10,262.93 325.10,254.07 329.81,254.07 329.81,254.07 331.05,254.07 331.05,254.07 332.29,254.07 332.29,254.07 333.53,254.07 333.53,245.48 335.77,245.48 335.77,237.11 342.22,237.11 342.22,228.92 344.95,228.92 344.95,220.87 345.45,220.87 345.45,220.87 361.08,220.87 361.08,212.96 386.15,212.96 386.15,212.96 386.65,212.96 386.65,212.96 392.11,212.96 392.11,205.15 394.34,205.15 394.34,197.44 398.31,197.44 398.31,189.82 403.52,189.82 403.52,182.28 406.25,182.28 406.25,182.28 408.24,182.28 408.24,174.81 409.98,174.81 409.98,167.41 439.51,167.41 439.51,160.07 442.49,160.07 442.49,152.78 444.47,152.78 444.47,152.78 447.20,152.78 447.20,152.78 458.37,152.78 458.37,152.78 461.10,152.78 461.10,145.55 467.06,145.55 467.06,138.37 470.53,138.37 470.53,131.23 471.77,131.23 471.77,124.14 475.00,124.14 475.00,124.14 486.42,124.14 486.42,124.14 492.37,124.14 492.37,124.14 494.86,124.14 494.86,124.14 497.34,124.14 497.34,124.14 516.70,124.14 516.70,124.14 516.94,124.14 516.94,117.09 524.64,117.09 524.64,117.09 530.35,117.09 530.35,110.07 530.84,110.07 530.84,103.10 536.05,103.10 536.05,103.10 545.98,103.10 545.98,96.16 558.64,96.16 558.64,89.26 563.60,89.26 563.60,89.26 579.49,89.26 579.49,89.26 588.17,89.26 588.17,89.26 588.67,89.26 588.67,89.26 595.37,89.26 595.37,82.39 603.31,82.39 603.31,75.55 616.96,75.55 616.96,75.55 627.39,75.55 627.39,68.75 632.85,68.75 632.85,61.97 639.55,61.97 639.55,55.23 646.50,55.23 646.50,55.23 652.45,55.23 652.45,48.51 660.15,48.51 660.15,48.51 672.31,48.51 672.31,41.83 676.28,41.83 676.28,41.83 679.26,41.83 679.26,41.83 679.26,159.90 679.26,159.90 676.28,159.90 676.28,159.90 672.31,159.90 672.31,165.59 660.15,165.59 660.15,165.59 652.45,165.59 652.45,171.25 646.50,171.25 646.50,171.25 639.55,171.25 639.55,176.88 632.85,176.88 632.85,182.48 627.39,182.48 627.39,188.04 616.96,188.04 616.96,188.04 603.31,188.04 603.31,193.58 595.37,193.58 595.37,199.07 588.67,199.07 588.67,199.07 588.17,199.07 588.17,199.07 579.49,199.07 579.49,199.07 563.60,199.07 563.60,199.07 558.64,199.07 558.64,204.53 545.98,204.53 545.98,209.96 536.05,209.96 536.05,209.96 530.84,209.96 530.84,215.34 530.35,215.34 530.35,220.68 524.64,220.68 524.64,220.68 516.94,220.68 516.94,225.98 516.70,225.98 516.70,225.98 497.34,225.98 497.34,225.98 494.86,225.98 494.86,225.98 492.37,225.98 492.37,225.98 486.42,225.98 486.42,225.98 475.00,225.98 475.00,225.98 471.77,225.98 471.77,231.23 470.53,231.23 470.53,236.44 467.06,236.44 467.06,241.59 461.10,241.59 461.10,246.69 458.37,246.69 458.37,246.69 447.20,246.69 447.20,246.69 444.47,246.69 444.47,246.69 442.49,246.69 442.49,251.73 439.51,251.73 439.51,256.71 409.98,256.71 409.98,261.62 408.24,261.62 408.24,266.46 406.25,266.46 406.25,266.46 403.52,266.46 403.52,271.21 398.31,271.21 398.31,275.88 394.34,275.88 394.34,280.45 392.11,280.45 392.11,284.91 386.65,284.91 386.65,284.91 386.15,284.91 386.15,284.91 361.08,284.91 361.08,289.24 345.45,289.24 345.45,289.24 344.95,289.24 344.95,293.42 342.22,293.42 342.22,297.43 335.77,297.43 335.77,301.23 333.53,301.23 333.53,304.76 332.29,304.76 332.29,304.76 331.05,304.76 331.05,304.76 329.81,304.76 329.81,304.76 325.10,304.76 325.10,307.93 312.93,307.93 312.93,310.62 299.78,310.62 299.78,312.51 240.46,312.51 240.46,312.51 215.89,312.51 ' style='stroke-width: 0.00; stroke: none; fill: #00BFC4; fill-opacity: 0.20;' />
+<polyline points='215.89,281.44 240.46,281.44 240.46,281.44 299.78,281.44 299.78,272.10 312.93,272.10 312.93,262.93 325.10,262.93 325.10,254.07 329.81,254.07 329.81,254.07 331.05,254.07 331.05,254.07 332.29,254.07 332.29,254.07 333.53,254.07 333.53,245.48 335.77,245.48 335.77,237.11 342.22,237.11 342.22,228.92 344.95,228.92 344.95,220.87 345.45,220.87 345.45,220.87 361.08,220.87 361.08,212.96 386.15,212.96 386.15,212.96 386.65,212.96 386.65,212.96 392.11,212.96 392.11,205.15 394.34,205.15 394.34,197.44 398.31,197.44 398.31,189.82 403.52,189.82 403.52,182.28 406.25,182.28 406.25,182.28 408.24,182.28 408.24,174.81 409.98,174.81 409.98,167.41 439.51,167.41 439.51,160.07 442.49,160.07 442.49,152.78 444.47,152.78 444.47,152.78 447.20,152.78 447.20,152.78 458.37,152.78 458.37,152.78 461.10,152.78 461.10,145.55 467.06,145.55 467.06,138.37 470.53,138.37 470.53,131.23 471.77,131.23 471.77,124.14 475.00,124.14 475.00,124.14 486.42,124.14 486.42,124.14 492.37,124.14 492.37,124.14 494.86,124.14 494.86,124.14 497.34,124.14 497.34,124.14 516.70,124.14 516.70,124.14 516.94,124.14 516.94,117.09 524.64,117.09 524.64,117.09 530.35,117.09 530.35,110.07 530.84,110.07 530.84,103.10 536.05,103.10 536.05,103.10 545.98,103.10 545.98,96.16 558.64,96.16 558.64,89.26 563.60,89.26 563.60,89.26 579.49,89.26 579.49,89.26 588.17,89.26 588.17,89.26 588.67,89.26 588.67,89.26 595.37,89.26 595.37,82.39 603.31,82.39 603.31,75.55 616.96,75.55 616.96,75.55 627.39,75.55 627.39,68.75 632.85,68.75 632.85,61.97 639.55,61.97 639.55,55.23 646.50,55.23 646.50,55.23 652.45,55.23 652.45,48.51 660.15,48.51 660.15,48.51 672.31,48.51 672.31,41.83 676.28,41.83 676.28,41.83 679.26,41.83 679.26,41.83 ' style='stroke-width: 1.07; stroke: none;' />
+<polyline points='679.26,159.90 679.26,159.90 676.28,159.90 676.28,159.90 672.31,159.90 672.31,165.59 660.15,165.59 660.15,165.59 652.45,165.59 652.45,171.25 646.50,171.25 646.50,171.25 639.55,171.25 639.55,176.88 632.85,176.88 632.85,182.48 627.39,182.48 627.39,188.04 616.96,188.04 616.96,188.04 603.31,188.04 603.31,193.58 595.37,193.58 595.37,199.07 588.67,199.07 588.67,199.07 588.17,199.07 588.17,199.07 579.49,199.07 579.49,199.07 563.60,199.07 563.60,199.07 558.64,199.07 558.64,204.53 545.98,204.53 545.98,209.96 536.05,209.96 536.05,209.96 530.84,209.96 530.84,215.34 530.35,215.34 530.35,220.68 524.64,220.68 524.64,220.68 516.94,220.68 516.94,225.98 516.70,225.98 516.70,225.98 497.34,225.98 497.34,225.98 494.86,225.98 494.86,225.98 492.37,225.98 492.37,225.98 486.42,225.98 486.42,225.98 475.00,225.98 475.00,225.98 471.77,225.98 471.77,231.23 470.53,231.23 470.53,236.44 467.06,236.44 467.06,241.59 461.10,241.59 461.10,246.69 458.37,246.69 458.37,246.69 447.20,246.69 447.20,246.69 444.47,246.69 444.47,246.69 442.49,246.69 442.49,251.73 439.51,251.73 439.51,256.71 409.98,256.71 409.98,261.62 408.24,261.62 408.24,266.46 406.25,266.46 406.25,266.46 403.52,266.46 403.52,271.21 398.31,271.21 398.31,275.88 394.34,275.88 394.34,280.45 392.11,280.45 392.11,284.91 386.65,284.91 386.65,284.91 386.15,284.91 386.15,284.91 361.08,284.91 361.08,289.24 345.45,289.24 345.45,289.24 344.95,289.24 344.95,293.42 342.22,293.42 342.22,297.43 335.77,297.43 335.77,301.23 333.53,301.23 333.53,304.76 332.29,304.76 332.29,304.76 331.05,304.76 331.05,304.76 329.81,304.76 329.81,304.76 325.10,304.76 325.10,307.93 312.93,307.93 312.93,310.62 299.78,310.62 299.78,312.51 240.46,312.51 240.46,312.51 215.89,312.51 ' style='stroke-width: 1.07; stroke: none;' />
+<rect x='53.83' y='28.26' width='655.21' height='298.37' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NS40OHw0MTAuMDg=)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NS40OHw0MTAuMDg=)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NS40OHw0MTAuMDg=)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NS40OHw0MTAuMDg=)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NS40OHw0MTAuMDg=)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NS40OHw0MTAuMDg=)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='48.90' y='316.10' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='48.90' y='250.81' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.1</text>
+<text x='48.90' y='185.52' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text x='48.90' y='120.24' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.3</text>
+<text x='48.90' y='54.95' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<polyline points='51.09,313.07 53.83,313.07 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='51.09,247.78 53.83,247.78 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='51.09,182.50 53.83,182.50 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='51.09,117.21 53.83,117.21 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='51.09,51.92 53.83,51.92 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NS40OHw0MTAuMDg=)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NS40OHw0MTAuMDg=)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='83.61,329.37 83.61,326.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='207.70,329.37 207.70,326.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='331.80,329.37 331.80,326.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='455.89,329.37 455.89,326.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='579.98,329.37 579.98,326.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='704.08,329.37 704.08,326.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='83.61' y='337.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='207.70' y='337.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='331.80' y='337.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='455.89' y='337.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>15</text>
+<text x='579.98' y='337.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='704.08' y='337.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>25</text>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NS40OHw0MTAuMDg=)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NS40OHw0MTAuMDg=)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='381.43' y='349.76' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='119.25px' lengthAdjust='spacingAndGlyphs'>Months to Death/Censor</text>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NS40OHw0MTAuMDg=)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text transform='translate(31.64,177.45) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='105.18px' lengthAdjust='spacingAndGlyphs'>Cumulative Incidence</text>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NS40OHw0MTAuMDg=)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NS40OHw0MTAuMDg=)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='320.32' y='363.00' width='122.22' height='28.24' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<rect x='331.28' y='368.48' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='333.01' y1='377.12' x2='346.83' y2='377.12' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<rect x='331.99' y='369.19' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: square; stroke-linejoin: miter; fill: #F8766D; fill-opacity: 0.20;' />
+<rect x='386.91' y='368.48' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='388.64' y1='377.12' x2='402.47' y2='377.12' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<rect x='387.62' y='369.19' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: square; stroke-linejoin: miter; fill: #00BFC4; fill-opacity: 0.20;' />
+<text x='354.04' y='380.15' style='font-size: 8.80px; font-family: sans;' textLength='27.39px' lengthAdjust='spacingAndGlyphs'>Drug A</text>
+<text x='409.67' y='380.15' style='font-size: 8.80px; font-family: sans;' textLength='27.39px' lengthAdjust='spacingAndGlyphs'>Drug B</text>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NS40OHw0MTAuMDg=)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NS40OHw0MTAuMDg=)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='53.83' y='20.04' style='font-size: 13.20px; font-family: sans;' textLength='92.47px' lengthAdjust='spacingAndGlyphs'>cuminc2-pvalue</text>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NS40OHw0MTAuMDg=)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='709.04' y='402.77' text-anchor='end' style='font-size: 8.80px; font-family: sans;' textLength='22.27px' lengthAdjust='spacingAndGlyphs'>p=0.2</text>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NS40OHw0MTAuMDg=)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NS40OHw0MTAuMDg=)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMTAuOTZ8NzA5LjA0fDEwLjk2fDEwLjk2'>
+    <rect x='10.96' y='10.96' width='698.08' height='0.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMTAuOTZ8NzA5LjA0fDEwLjk2fDEwLjk2)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpMTAuOTZ8NzA5LjA0fDEwLjk2fDEwLjk2)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMTAuOTZ8NzA5LjA0fDQwNC42MHw0MDQuNjA='>
+    <rect x='10.96' y='404.60' width='698.08' height='0.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMTAuOTZ8NzA5LjA0fDQwNC42MHw0MDQuNjA=)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMTAuOTZ8NzA5LjA0fDQxNS41Nnw0ODQuODI='>
+    <rect x='10.96' y='415.56' width='698.08' height='69.26' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMTAuOTZ8NzA5LjA0fDQxNS41Nnw0ODQuODI=)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NDEwLjA4fDQ5MC4zMA==)'>
+<rect x='5.48' y='410.08' width='709.04' height='80.22' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpNTMuODN8NzA5LjA0fDQzOC45Mnw0ODcuNTY='>
+    <rect x='53.83' y='438.92' width='655.21' height='48.64' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTMuODN8NzA5LjA0fDQzOC45Mnw0ODcuNTY=)'>
+<rect x='53.83' y='438.92' width='655.21' height='48.64' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='83.61' y='477.08' text-anchor='middle' style='font-size: 8.11px; font-family: sans;' textLength='4.51px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='83.61' y='454.97' text-anchor='middle' style='font-size: 8.11px; font-family: sans;' textLength='9.02px' lengthAdjust='spacingAndGlyphs'>98</text>
+<text x='207.70' y='477.08' text-anchor='middle' style='font-size: 8.11px; font-family: sans;' textLength='4.51px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='207.70' y='454.97' text-anchor='middle' style='font-size: 8.11px; font-family: sans;' textLength='9.02px' lengthAdjust='spacingAndGlyphs'>97</text>
+<text x='331.80' y='477.08' text-anchor='middle' style='font-size: 8.11px; font-family: sans;' textLength='4.51px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='331.80' y='454.97' text-anchor='middle' style='font-size: 8.11px; font-family: sans;' textLength='9.02px' lengthAdjust='spacingAndGlyphs'>94</text>
+<text x='455.89' y='477.08' text-anchor='middle' style='font-size: 8.11px; font-family: sans;' textLength='4.51px' lengthAdjust='spacingAndGlyphs'>7</text>
+<text x='455.89' y='454.97' text-anchor='middle' style='font-size: 8.11px; font-family: sans;' textLength='9.02px' lengthAdjust='spacingAndGlyphs'>83</text>
+<text x='579.98' y='477.08' text-anchor='middle' style='font-size: 8.11px; font-family: sans;' textLength='9.02px' lengthAdjust='spacingAndGlyphs'>17</text>
+<text x='579.98' y='454.97' text-anchor='middle' style='font-size: 8.11px; font-family: sans;' textLength='9.02px' lengthAdjust='spacingAndGlyphs'>61</text>
+<text x='704.08' y='477.08' text-anchor='middle' style='font-size: 8.11px; font-family: sans;' textLength='9.02px' lengthAdjust='spacingAndGlyphs'>24</text>
+<text x='704.08' y='454.97' text-anchor='middle' style='font-size: 8.11px; font-family: sans;' textLength='4.51px' lengthAdjust='spacingAndGlyphs'>0</text>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NDEwLjA4fDQ5MC4zMA==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NDEwLjA4fDQ5MC4zMA==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NDEwLjA4fDQ5MC4zMA==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NDEwLjA4fDQ5MC4zMA==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NDEwLjA4fDQ5MC4zMA==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NDEwLjA4fDQ5MC4zMA==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='48.90' y='477.05' text-anchor='end' style='font-size: 8.00px; font-family: sans;' textLength='24.47px' lengthAdjust='spacingAndGlyphs'>Events</text>
+<text x='48.90' y='454.94' text-anchor='end' style='font-size: 8.00px; font-family: sans;' textLength='25.34px' lengthAdjust='spacingAndGlyphs'>At Risk</text>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NDEwLjA4fDQ5MC4zMA==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NDEwLjA4fDQ5MC4zMA==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NDEwLjA4fDQ5MC4zMA==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NDEwLjA4fDQ5MC4zMA==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NDEwLjA4fDQ5MC4zMA==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NDEwLjA4fDQ5MC4zMA==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NDEwLjA4fDQ5MC4zMA==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NDEwLjA4fDQ5MC4zMA==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='53.83' y='433.44' style='font-size: 10.00px; font-family: sans;' textLength='31.13px' lengthAdjust='spacingAndGlyphs'>Drug A</text>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NDEwLjA4fDQ5MC4zMA==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NDEwLjA4fDQ5MC4zMA==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NDEwLjA4fDQ5MC4zMA==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMTAuOTZ8NzA5LjA0fDQxNS41Nnw0MTUuNTY='>
+    <rect x='10.96' y='415.56' width='698.08' height='0.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMTAuOTZ8NzA5LjA0fDQxNS41Nnw0MTUuNTY=)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpMTAuOTZ8NzA5LjA0fDQxNS41Nnw0MTUuNTY=)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMTAuOTZ8NzA5LjA0fDQ4NC44Mnw0ODQuODI='>
+    <rect x='10.96' y='484.82' width='698.08' height='0.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMTAuOTZ8NzA5LjA0fDQ4NC44Mnw0ODQuODI=)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMTAuOTZ8NzA5LjA0fDQ5NS43OHw1NjUuMDQ='>
+    <rect x='10.96' y='495.78' width='698.08' height='69.26' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMTAuOTZ8NzA5LjA0fDQ5NS43OHw1NjUuMDQ=)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NDkwLjMwfDU3MC41Mg==)'>
+<rect x='5.48' y='490.30' width='709.04' height='80.22' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpNTMuODN8NzA5LjA0fDUxOS4xNHw1NjcuNzg='>
+    <rect x='53.83' y='519.14' width='655.21' height='48.64' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTMuODN8NzA5LjA0fDUxOS4xNHw1NjcuNzg=)'>
+<rect x='53.83' y='519.14' width='655.21' height='48.64' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='83.61' y='557.30' text-anchor='middle' style='font-size: 8.11px; font-family: sans;' textLength='4.51px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='83.61' y='535.19' text-anchor='middle' style='font-size: 8.11px; font-family: sans;' textLength='13.53px' lengthAdjust='spacingAndGlyphs'>102</text>
+<text x='207.70' y='557.30' text-anchor='middle' style='font-size: 8.11px; font-family: sans;' textLength='4.51px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='207.70' y='535.19' text-anchor='middle' style='font-size: 8.11px; font-family: sans;' textLength='13.53px' lengthAdjust='spacingAndGlyphs'>102</text>
+<text x='331.80' y='557.30' text-anchor='middle' style='font-size: 8.11px; font-family: sans;' textLength='4.51px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='331.80' y='535.19' text-anchor='middle' style='font-size: 8.11px; font-family: sans;' textLength='9.02px' lengthAdjust='spacingAndGlyphs'>95</text>
+<text x='455.89' y='557.30' text-anchor='middle' style='font-size: 8.11px; font-family: sans;' textLength='9.02px' lengthAdjust='spacingAndGlyphs'>17</text>
+<text x='455.89' y='535.19' text-anchor='middle' style='font-size: 8.11px; font-family: sans;' textLength='9.02px' lengthAdjust='spacingAndGlyphs'>75</text>
+<text x='579.98' y='557.30' text-anchor='middle' style='font-size: 8.11px; font-family: sans;' textLength='9.02px' lengthAdjust='spacingAndGlyphs'>26</text>
+<text x='579.98' y='535.19' text-anchor='middle' style='font-size: 8.11px; font-family: sans;' textLength='9.02px' lengthAdjust='spacingAndGlyphs'>55</text>
+<text x='704.08' y='557.30' text-anchor='middle' style='font-size: 8.11px; font-family: sans;' textLength='9.02px' lengthAdjust='spacingAndGlyphs'>33</text>
+<text x='704.08' y='535.19' text-anchor='middle' style='font-size: 8.11px; font-family: sans;' textLength='4.51px' lengthAdjust='spacingAndGlyphs'>0</text>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NDkwLjMwfDU3MC41Mg==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NDkwLjMwfDU3MC41Mg==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NDkwLjMwfDU3MC41Mg==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NDkwLjMwfDU3MC41Mg==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NDkwLjMwfDU3MC41Mg==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NDkwLjMwfDU3MC41Mg==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='48.90' y='557.27' text-anchor='end' style='font-size: 8.00px; font-family: sans;' textLength='24.47px' lengthAdjust='spacingAndGlyphs'>Events</text>
+<text x='48.90' y='535.16' text-anchor='end' style='font-size: 8.00px; font-family: sans;' textLength='25.34px' lengthAdjust='spacingAndGlyphs'>At Risk</text>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NDkwLjMwfDU3MC41Mg==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NDkwLjMwfDU3MC41Mg==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NDkwLjMwfDU3MC41Mg==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NDkwLjMwfDU3MC41Mg==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NDkwLjMwfDU3MC41Mg==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NDkwLjMwfDU3MC41Mg==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NDkwLjMwfDU3MC41Mg==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NDkwLjMwfDU3MC41Mg==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='53.83' y='513.66' style='font-size: 10.00px; font-family: sans;' textLength='31.13px' lengthAdjust='spacingAndGlyphs'>Drug B</text>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NDkwLjMwfDU3MC41Mg==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NDkwLjMwfDU3MC41Mg==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8NDkwLjMwfDU3MC41Mg==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMTAuOTZ8NzA5LjA0fDQ5NS43OHw0OTUuNzg='>
+    <rect x='10.96' y='495.78' width='698.08' height='0.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMTAuOTZ8NzA5LjA0fDQ5NS43OHw0OTUuNzg=)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpMTAuOTZ8NzA5LjA0fDQ5NS43OHw0OTUuNzg=)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMTAuOTZ8NzA5LjA0fDU2NS4wNHw1NjUuMDQ='>
+    <rect x='10.96' y='565.04' width='698.08' height='0.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMTAuOTZ8NzA5LjA0fDU2NS4wNHw1NjUuMDQ=)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+</svg>

--- a/tests/testthat/test-add_pvalue.R
+++ b/tests/testthat/test-add_pvalue.R
@@ -38,13 +38,15 @@ test_that("add_pvalue() works", {
 
   # no error with ggcuminc()
   expect_error(
-    tidycmprsk::cuminc(Surv(ttdeath, death_cr) ~ trt, tidycmprsk::trial) %>%
+    pvalue_cuminc <-
+      tidycmprsk::cuminc(Surv(ttdeath, death_cr) ~ trt, tidycmprsk::trial) %>%
       ggcuminc(outcome = "death from cancer") +
       add_confidence_interval() +
       add_risktable() +
       add_pvalue(),
     NA
   )
+  vdiffr::expect_doppelganger("cuminc2-pvalue", pvalue_cuminc)
 
   expect_error(
     (survfit2(Surv(time, status) ~ surg, df_colon) %>%


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Adding ability to report comparative p-values from cumulative incidence plots created with `tidycmprsk::cuminc()` (#84)

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #84

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] Ensure all package dependencies are installed by running `renv::install()`
- [ ] PR branch has pulled the most recent updates from master branch. Ensure the pull request branch and your local version match and both have the latest updates from the master branch.
- [ ] If a new function was added, function included in `_pkgdown.yml`
- [ ] If a bug was fixed, a unit test was added for the bug check
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Overall code coverage remains >99.5%. Review coverage with `withr::with_envvar(new = c("NOT_CRAN" = "true"), covr::report())`. Begin in a fresh R session without any packages loaded. 
- [ ] R CMD Check runs without errors, warnings, and notes
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# ggsurvfit (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `codemetar::write_codemeta()`
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

