### PR TITLE
x-axis label with `Surv_CNSR()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ggsurvfit
 Title: Flexible Time-to-Event Figures
-Version: 0.1.0.9009
+Version: 0.1.0.9010
 Authors@R: c(
     person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0003-0862-2018")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * When using a CDISC ADTTE data frame, the label saved in PARAM/PARAMCD will be used as the default x-axis label in `ggsurvfit()`. (#97)
 
+* Bug fix when `Surv_CNSR()` is used in conjunction with `ggsurvfit()`. The default x-axis label is incorrectly attributed to a stratifying variable, when present.
+
 * Fix in `survfit2()` that allows users to pass arguments with non-standard evaluation, i.e. bare column names. (#90)
 
 * When the `survfit(weights=)` argument is utilized the number at risk, number of observed events, etc. are a non-integer numbers. The counts in the risk table are now rounded to the nearest integer. (#90)

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * When using a CDISC ADTTE data frame, the label saved in PARAM/PARAMCD will be used as the default x-axis label in `ggsurvfit()`. (#97)
 
-* Bug fix when `Surv_CNSR()` is used in conjunction with `ggsurvfit()`. The default x-axis label is incorrectly attributed to a stratifying variable, when present.
+* Bug fix when `Surv_CNSR()` is used in conjunction with `ggsurvfit()`. The default x-axis label is incorrectly attributed to a stratifying variable, when present. (#100)
 
 * Fix in `survfit2()` that allows users to pass arguments with non-standard evaluation, i.e. bare column names. (#90)
 

--- a/R/ggsurvfit.R
+++ b/R/ggsurvfit.R
@@ -184,18 +184,18 @@ ggsurvfit <- function(x, type = "survival",
 .default_x_axis_label <- function(x) {
   # extract formula and data ---------------------------------------------------
   if (inherits(x, "survfit2")) {
-    formula <- .extract_formula_from_survfit(x)
+    formula <- .extract_formula_from_survfit(x) %>% rlang::f_lhs()
     data <- .extract_data_from_survfit(x)
   }
   else if (inherits(x, "tidycuminc")) {
-    formula <- x$formula
+    formula <- x$formula %>% rlang::f_lhs()
     data <- x$data
   } else {
     formula <- data <- NULL
   }
 
   # extract time variable ------------------------------------------------------
-  if (!is.null(formula)) {
+  if (!rlang::is_empty(formula) && !rlang::is_empty(all.vars(formula))) {
     time_variable <-
       formula %>%
       all.vars() %>%
@@ -217,7 +217,10 @@ ggsurvfit <- function(x, type = "survival",
       unique() %>%
       paste(collapse = ", ")
   ) %||%
-  attr(data[[time_variable]], "label") %||%
+    switch(
+      !is.null(time_variable) && !is.null(data),
+      attr(data[[time_variable]], "label")
+    ) %||%
     time_variable %||%
     "time"
 }

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -7,8 +7,9 @@ CMD
 Codecov
 KMunicate
 Kaplan
-Lifecycle
 ORCID
+PARAM
+PARAMCD
 PFS
 Surv
 Survfit
@@ -18,6 +19,7 @@ cuminc
 geoms
 geom’
 ggcuminc
+ggeasy
 gghighlight
 ggplot
 grey

--- a/tests/testthat/test-ggsurvfit.R
+++ b/tests/testthat/test-ggsurvfit.R
@@ -73,6 +73,17 @@ test_that("ggsurvfit() works", {
     adtte[["PARAM"]] %>% unique()
   )
 
+  # testing the default label when using Surv_CNSR() without a PARAM COLUMN
+  expect_equal(
+    survfit2(
+      Surv_CNSR() ~ STR01L,
+      data = adtte %>% dplyr::select(-c(PARAM, PARAMCD))
+    ) %>%
+      .default_x_axis_label(),
+    "time"
+  )
+
+
   expect_error(ggsurvfit(mtcars))
   expect_error(survfit2(Surv(ttdeath, death_cr) ~ trt, tidycmprsk::trial) %>% ggsurvfit())
 })


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Bug fix when `Surv_CNSR()` is used in conjunction with `ggsurvfit()`. The default x-axis label is incorrectly attributed to a stratifying variable, when present.


--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] Ensure all package dependencies are installed by running `renv::install()`
- [ ] PR branch has pulled the most recent updates from master branch. Ensure the pull request branch and your local version match and both have the latest updates from the master branch.
- [ ] If a new function was added, function included in `_pkgdown.yml`
- [ ] If a bug was fixed, a unit test was added for the bug check
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Overall code coverage remains >99.5%. Review coverage with `withr::with_envvar(new = c("NOT_CRAN" = "true"), covr::report())`. Begin in a fresh R session without any packages loaded. 
- [ ] R CMD Check runs without errors, warnings, and notes
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# ggsurvfit (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `codemetar::write_codemeta()`
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

